### PR TITLE
Integrate Formspree handling for contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@
                             <p class="flex items-center"><svg class="w-5 h-5 mr-3 theme-primary" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg> <a href="#" target="_blank" class="hover:underline">GitHub Profile</a></p>
                         </div>
                     </div>
-                    <form class="md:w-1/2 space-y-4">
+                    <form id="contact-form" action="https://formspree.io/f/xqallpwj" method="POST" class="md:w-1/2 space-y-4">
                         <div>
                             <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
                             <input type="text" id="name" name="name" class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
@@ -315,6 +315,7 @@
                             <textarea id="message" name="message" rows="4" class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"></textarea>
                         </div>
                         <button type="submit" class="w-full bg-theme-primary text-white font-bold py-3 px-6 rounded-lg shadow-lg hover-bg-theme-primary-dark transition-colors">Send Message</button>
+                        <p id="contact-success" class="hidden text-green-700 bg-green-50 border border-green-200 rounded-lg p-4 text-sm">Thanks for reaching out! I'll get back to you shortly.</p>
                     </form>
                 </div>
             </div>
@@ -719,6 +720,42 @@
             document.querySelectorAll('.fade-in-section').forEach(section => {
                 fadeObserver.observe(section);
             });
+
+            // Contact form submission
+            const contactForm = document.getElementById('contact-form');
+            const contactSuccess = document.getElementById('contact-success');
+
+            if (contactForm && contactSuccess) {
+                const hideSuccessMessage = () => contactSuccess.classList.add('hidden');
+
+                contactForm.addEventListener('submit', async (event) => {
+                    event.preventDefault();
+                    hideSuccessMessage();
+
+                    try {
+                        const response = await fetch(contactForm.action, {
+                            method: 'POST',
+                            headers: { 'Accept': 'application/json' },
+                            body: new FormData(contactForm)
+                        });
+
+                        if (response.ok) {
+                            contactSuccess.textContent = "Thanks for reaching out! I'll get back to you shortly.";
+                            contactSuccess.classList.remove('hidden');
+                            contactForm.reset();
+                        } else {
+                            throw new Error('Form submission failed');
+                        }
+                    } catch (error) {
+                        contactSuccess.textContent = "Oops! Something went wrong. Please try again later.";
+                        contactSuccess.classList.remove('hidden');
+                    }
+                });
+
+                contactForm.querySelectorAll('input, textarea').forEach(field => {
+                    field.addEventListener('input', hideSuccessMessage);
+                });
+            }
 
             // --- INITIALIZATION ---
             renderProjects();


### PR DESCRIPTION
## Summary
- connect the contact form to the Formspree endpoint and add inline success feedback styling
- add a client-side submission handler to post form data via fetch and display success or error messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4ae7bcb4c832d9c5d029fa84bdc86